### PR TITLE
Print out the version during processing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 set -e
+sh -c "black --version"
 sh -c "black $*"


### PR DESCRIPTION
Black recently cut a new release and it confused a few of our contributors since our CI suddenly broke and everybody needed to upgrade the version of black they use. It'd help if this repo simply printed the version it was using.